### PR TITLE
Fix platform toolset not found issue.

### DIFF
--- a/Build.proj
+++ b/Build.proj
@@ -41,11 +41,11 @@ MSBuild.exe "Build.proj"
       <PlatformsFiles Include="$(MSBuildThisFileDirectory)\YY.Build.Linux.Tasks\Targets\Platforms\**\*.*"/>
     </ItemGroup>
     <Copy SourceFiles="@(PlatformsRootFiles)" DestinationFolder="$(MSBuildThisFileDirectory)\Release\VCTargets\v170\Application Type\Linux\1.0" />
-    <Copy SourceFiles="@(PlatformsFiles)" DestinationFiles="$(MSBuildThisFileDirectory)\Release\VCTargets\v170\Application Type\Linux\1.0\Platforms\ARM\%(RecursiveDir)%(Filename)%(Extension)" />
-    <Copy SourceFiles="@(PlatformsFiles)" DestinationFiles="$(MSBuildThisFileDirectory)\Release\VCTargets\v170\Application Type\Linux\1.0\Platforms\ARM64\%(RecursiveDir)%(Filename)%(Extension)" />
-    <Copy SourceFiles="@(PlatformsFiles)" DestinationFiles="$(MSBuildThisFileDirectory)\Release\VCTargets\v170\Application Type\Linux\1.0\Platforms\MIPS\%(RecursiveDir)%(Filename)%(Extension)" />
-    <Copy SourceFiles="@(PlatformsFiles)" DestinationFiles="$(MSBuildThisFileDirectory)\Release\VCTargets\v170\Application Type\Linux\1.0\Platforms\x64\%(RecursiveDir)%(Filename)%(Extension)" />
-    <Copy SourceFiles="@(PlatformsFiles)" DestinationFiles="$(MSBuildThisFileDirectory)\Release\VCTargets\v170\Application Type\Linux\1.0\Platforms\x86\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Copy SourceFiles="@(PlatformsFiles)" DestinationFiles="$(MSBuildThisFileDirectory)\Release\VCTargets\v170\Application Type\Linux\1.0\Platforms\ARM\PlatformToolsets\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Copy SourceFiles="@(PlatformsFiles)" DestinationFiles="$(MSBuildThisFileDirectory)\Release\VCTargets\v170\Application Type\Linux\1.0\Platforms\ARM64\PlatformToolsets\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Copy SourceFiles="@(PlatformsFiles)" DestinationFiles="$(MSBuildThisFileDirectory)\Release\VCTargets\v170\Application Type\Linux\1.0\Platforms\MIPS\PlatformToolsets\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Copy SourceFiles="@(PlatformsFiles)" DestinationFiles="$(MSBuildThisFileDirectory)\Release\VCTargets\v170\Application Type\Linux\1.0\Platforms\x64\PlatformToolsets\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Copy SourceFiles="@(PlatformsFiles)" DestinationFiles="$(MSBuildThisFileDirectory)\Release\VCTargets\v170\Application Type\Linux\1.0\Platforms\x86\PlatformToolsets\%(RecursiveDir)%(Filename)%(Extension)" />
   </Target>
   
   <Target Name="_GetProjectAllConfiguration" Returns="@(AllProjectReferenceConfigurations)">


### PR DESCRIPTION
Fix for that issue.

> dotnet build ConsoleApplication/ConsoleApplication.vcxproj -p:Configuration=Release;Platform=x64
```
/home/mouri/Workspace/MSBuildCpp/Release/VCTargets/v170/Microsoft.CppBuild.targets(447,5): error MSB8020: The build tools for 'YY_Cross_GCC_1_0' application Type Linux (Platform Toolset = 'YY_Cross_GCC_1_0') cannot be found. Please install the workflow for this application type and include the build tools for the  [/home/mouri/Workspace/MSBuildCpp/Sample/ConsoleApplication/ConsoleApplication.vcxproj]
```

Kenji Mouri